### PR TITLE
Bump RxSwift to 6.0.0+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/Moya/ReactiveSwift.git", .upToNextMajor(from: "6.1.0")),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")), // dev
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")), // dev
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0")), // dev


### PR DESCRIPTION
This bumps the RxSwift dependency to 6.0.0+ to avoid dependency conflicts downstream in Odyssey.

I tested this out by pointing to the local package and building Odyssey.